### PR TITLE
Adding _blank target for tweet link

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
 
 <h2 class="earthday" style="color:white !important;">
 <br>
-<a id="tweet" style="display:none;color:white;text-decoration:none;margin-top:-120px !important;" href="https://twitter.com/home?status=The%20planet%20thinks%20this%20about%20cats...http%3A//hivemind.fun .Try%20the%20%23hivemind%20by%20%40craftfortress"># H I V E M I N D</a>
+<a id="tweet" target="_blank" style="display:none;color:white;text-decoration:none;margin-top:-120px !important;" href="https://twitter.com/home?status=The%20planet%20thinks%20this%20about%20cats...http%3A//hivemind.fun .Try%20the%20%23hivemind%20by%20%40craftfortress"># H I V E M I N D</a>
 <p style="text-align:middle;width:100%;font-size:14px;text-decoration:none;text-shadow:0px;font-family:courier;">
 <a id="link" style="display:none;color:white;top:80%;text-decoration:none;" href="http://hivemind.fun">h i v e m i n d . f u n</a>
 </p>


### PR DESCRIPTION
The current behavior of tweet link (#HIVEMIND) loads http://hivemind.fun/ 
Adding target resolves the issue and creates a better experience: Enables the user to tweet different stuff multiple times.